### PR TITLE
feat: Implement GTM, Consent Mode, SEO compatibility, and Cookie Banner

### DIFF
--- a/dadecore-theme/assets/css/cookie-banner.css
+++ b/dadecore-theme/assets/css/cookie-banner.css
@@ -1,0 +1,244 @@
+/* Cookie Consent Banner Styles */
+#dadecore-cookie-consent-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: var(--wp--preset--color--gris-oscuro, #333);
+    color: var(--wp--preset--color--light, #fff);
+    padding: var(--wp--preset--spacing--medium, 1rem);
+    z-index: 10000;
+    box-shadow: 0 -2px 10px rgba(0,0,0,0.2);
+    font-size: var(--wp--preset--font-size--small, 0.875rem);
+    display: none; /* Hidden by default, shown by JS */
+}
+
+#dadecore-cookie-consent-banner .cookie-banner-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--wp--preset--spacing--small, 0.75rem);
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+@media (min-width: 768px) {
+    #dadecore-cookie-consent-banner .cookie-banner-content {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+    }
+}
+
+#dadecore-cookie-consent-banner .cookie-banner-text {
+    flex-grow: 1;
+    line-height: 1.6;
+}
+
+#dadecore-cookie-consent-banner .cookie-banner-text p {
+    margin: 0 0 var(--wp--preset--spacing--x-small, 0.5rem);
+    color: var(--wp--preset--color--light, #fff); /* Ensure paragraph text is light */
+}
+
+#dadecore-cookie-consent-banner .cookie-banner-text a {
+    color: var(--wp--preset--color--verde-tech, #00F5A0);
+    text-decoration: underline;
+}
+
+#dadecore-cookie-consent-banner .cookie-banner-actions {
+    display: flex;
+    gap: var(--wp--preset--spacing--small, 0.75rem);
+    flex-wrap: wrap; /* Allow buttons to wrap on small screens */
+}
+
+#dadecore-cookie-consent-banner .cookie-banner-actions button {
+    background-color: var(--wp--preset--color--primary, #0057B8);
+    color: var(--wp--preset--color--light, #fff);
+    border: none;
+    padding: var(--wp--preset--spacing--x-small, 0.5rem) var(--wp--preset--spacing--medium, 1rem);
+    border-radius: var(--wp--preset--border--radius--small, 0.25rem);
+    cursor: pointer;
+    font-size: इन्हेरिट;
+    transition: background-color 0.2s ease;
+}
+
+#dadecore-cookie-consent-banner .cookie-banner-actions button:hover {
+    background-color: var(--wp--preset--color--secondary, #FF6F00);
+}
+
+#dadecore-cookie-consent-banner .cookie-banner-actions button.decline {
+    background-color: var(--wp--preset--color--gris-medio, #ccc);
+    color: var(--wp--preset--color--gris-oscuro, #333);
+}
+#dadecore-cookie-consent-banner .cookie-banner-actions button.decline:hover {
+    background-color: var(--wp--preset--color--gris-claro, #f0f0f0);
+}
+
+#dadecore-cookie-consent-banner .cookie-banner-actions button.settings {
+    background-color: transparent;
+    border: 1px solid var(--wp--preset--color--light, #fff);
+}
+#dadecore-cookie-consent-banner .cookie-banner-actions button.settings:hover {
+    background-color: rgba(255,255,255,0.1);
+}
+
+
+/* Cookie Settings Modal */
+#dadecore-cookie-settings-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0,0,0,0.7);
+    z-index: 10001;
+    display: none; /* Hidden by default */
+    align-items: center;
+    justify-content: center;
+    padding: var(--wp--preset--spacing--medium, 1rem);
+    overflow-y: auto;
+}
+
+#dadecore-cookie-settings-modal .modal-content {
+    background-color: var(--wp--preset--color--light, #fff);
+    color: var(--wp--preset--color--gris-oscuro, #333);
+    padding: var(--wp--preset--spacing--large, 1.5rem);
+    border-radius: var(--wp--preset--border--radius--medium, 0.5rem);
+    max-width: 600px;
+    width: 100%;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+}
+
+#dadecore-cookie-settings-modal .modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid var(--wp--preset--color--gris-claro, #f0f0f0);
+    padding-bottom: var(--wp--preset--spacing--small, 0.75rem);
+    margin-bottom: var(--wp--preset--spacing--medium, 1rem);
+}
+
+#dadecore-cookie-settings-modal .modal-header h3 {
+    margin: 0;
+    font-size: var(--wp--preset--font-size--large, 1.5rem);
+}
+
+#dadecore-cookie-settings-modal .modal-close-button {
+    background: none;
+    border: none;
+    font-size: 1.8rem;
+    cursor: pointer;
+    padding: 0;
+    line-height: 1;
+}
+
+#dadecore-cookie-settings-modal .modal-body .category {
+    margin-bottom: var(--wp--preset--spacing--medium, 1rem);
+    padding-bottom: var(--wp--preset--spacing--small, 0.75rem);
+    border-bottom: 1px solid var(--wp--preset--color--gris-claro, #f0f0f0);
+}
+#dadecore-cookie-settings-modal .modal-body .category:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+}
+
+#dadecore-cookie-settings-modal .modal-body .category-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--wp--preset--spacing--x-small, 0.5rem);
+}
+
+#dadecore-cookie-settings-modal .modal-body .category-header label {
+    font-weight: bold;
+    font-size: var(--wp--preset--font-size--medium, 1.125rem);
+}
+
+#dadecore-cookie-settings-modal .modal-body .category-description {
+    font-size: var(--wp--preset--font-size--small, 0.875rem);
+    line-height: 1.5;
+    margin-bottom: var(--wp--preset--spacing--x-small, 0.5rem);
+}
+
+#dadecore-cookie-settings-modal .modal-footer {
+    margin-top: var(--wp--preset--spacing--medium, 1rem);
+    padding-top: var(--wp--preset--spacing--medium, 1rem);
+    border-top: 1px solid var(--wp--preset--color--gris-claro, #f0f0f0);
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--wp--preset--spacing--small, 0.75rem);
+}
+
+#dadecore-cookie-settings-modal .modal-footer button {
+    background-color: var(--wp--preset--color--primary, #0057B8);
+    color: var(--wp--preset--color--light, #fff);
+    border: none;
+    padding: var(--wp--preset--spacing--x-small, 0.5rem) var(--wp--preset--spacing--medium, 1rem);
+    border-radius: var(--wp--preset--border--radius--small, 0.25rem);
+    cursor: pointer;
+    font-size: इन्हेरिट;
+}
+#dadecore-cookie-settings-modal .modal-footer button:hover {
+    background-color: var(--wp--preset--color--secondary, #FF6F00);
+}
+
+/* Switch toggle styles */
+.dadecore-cookie-toggle {
+    position: relative;
+    display: inline-block;
+    width: 44px; /* Reduced size */
+    height: 24px; /* Reduced size */
+}
+
+.dadecore-cookie-toggle input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.dadecore-cookie-toggle .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: .4s;
+    border-radius: 24px; /* Keep it round */
+}
+
+.dadecore-cookie-toggle .slider:before {
+    position: absolute;
+    content: "";
+    height: 18px; /* Reduced size */
+    width: 18px;  /* Reduced size */
+    left: 3px;    /* Adjusted position */
+    bottom: 3px;  /* Adjusted position */
+    background-color: white;
+    transition: .4s;
+    border-radius: 50%;
+}
+
+.dadecore-cookie-toggle input:checked + .slider {
+    background-color: var(--wp--preset--color--verde-tech, #2196F3);
+}
+
+.dadecore-cookie-toggle input:focus + .slider {
+    box-shadow: 0 0 1px var(--wp--preset--color--verde-tech, #2196F3);
+}
+
+.dadecore-cookie-toggle input:checked + .slider:before {
+    transform: translateX(20px); /* Adjusted translation */
+}
+
+.dadecore-cookie-toggle.disabled .slider {
+    background-color: #aaa; /* Darker grey for disabled */
+    cursor: not-allowed;
+}
+
+.dadecore-cookie-toggle.disabled .slider:before {
+    background-color: #eee; /* Lighter grey for disabled knob */
+}
+#dadecore-cookie-settings-modal .modal-body .category-header .dadecore-cookie-toggle {
+    flex-shrink: 0; /* Prevent toggle from shrinking */
+}

--- a/dadecore-theme/assets/js/cookie-consent.js
+++ b/dadecore-theme/assets/js/cookie-consent.js
@@ -1,0 +1,285 @@
+/**
+ * Dadecore Cookie Consent Banner
+ */
+document.addEventListener('DOMContentLoaded', function () {
+    // Check if settings are localized
+    if (typeof dadecoreCookieConsent === 'undefined') {
+        console.warn('Cookie Consent settings not found. Aborting initialization.');
+        return;
+    }
+
+    const settings = dadecoreCookieConsent;
+    const consentCookieName = 'dadecore_cookie_consent';
+    const gtmId = settings.gtmId;
+
+    // DOM Elements
+    let bannerElement = null;
+    let modalElement = null;
+
+    // Default consent state structure
+    const defaultConsents = {
+        necessary: true, // Always true
+        analytics: settings.categories.analytics ? settings.categories.analytics.defaultEnabled : false,
+        marketing: settings.categories.marketing ? settings.categories.marketing.defaultEnabled : false,
+    };
+
+    const consentMapping = {
+        analytics: 'analytics_storage',
+        marketing: 'ad_storage' // Also potentially 'ad_user_data', 'ad_personalization'
+                                // For simplicity, mapping marketing to ad_storage.
+                                // Functionality & Personalization could be mapped if categories are added.
+    };
+
+
+    function getConsent() {
+        const cookie = document.cookie.split('; ').find(row => row.startsWith(consentCookieName + '='));
+        if (cookie) {
+            try {
+                return JSON.parse(decodeURIComponent(cookie.split('=')[1]));
+            } catch (e) {
+                return null;
+            }
+        }
+        // For broader compatibility and larger storage, check localStorage as primary
+        const storedConsent = localStorage.getItem(consentCookieName);
+        if (storedConsent) {
+            try {
+                return JSON.parse(storedConsent);
+            } catch(e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    function setConsent(consents, expirationDays = 365) {
+        const consentStateToStore = {
+            necessary: true, // Always true
+            analytics: consents.analytics === true,
+            marketing: consents.marketing === true,
+            timestamp: new Date().getTime()
+        };
+
+        // Store in localStorage (primary)
+        localStorage.setItem(consentCookieName, JSON.stringify(consentStateToStore));
+
+        // Set a small cookie for server-side checks or as a fallback indicator
+        const date = new Date();
+        date.setTime(date.getTime() + (expirationDays * 24 * 60 * 60 * 1000));
+        const expires = "expires=" + date.toUTCString();
+        document.cookie = consentCookieName + "=" + encodeURIComponent(JSON.stringify({ consented: true, ts: consentStateToStore.timestamp })) + ";" + expires + ";path=/;SameSite=Lax";
+
+        updateGtmConsent(consentStateToStore);
+    }
+
+    function updateGtmConsent(consents) {
+        if (typeof gtag !== 'function' || !settings.consentModeEnabled) {
+            // console.log('gtag not available or Consent Mode disabled. Skipping GTM update.');
+            return;
+        }
+
+        const gtmConsentPayload = {
+            // Basic GCM types. functionality_storage, personalization_storage, security_storage can be added if needed
+            'analytics_storage': consents.analytics ? 'granted' : 'denied',
+            'ad_storage': consents.marketing ? 'granted' : 'denied', // Basic mapping
+            // If you have more granular categories that map to GCM types:
+            // 'functionality_storage': consents.functionality ? 'granted' : 'denied',
+            // 'personalization_storage': consents.personalization ? 'granted' : 'denied',
+        };
+
+        // Potentially add ad_user_data and ad_personalization based on marketing consent
+        if (settings.consentModeEnabled) { // Check again, just in case
+            gtag('consent', 'update', gtmConsentPayload);
+            // console.log('GTM Consent Updated:', gtmConsentPayload);
+
+            // If marketing consent is granted, and you need to send ad_user_data, ad_personalization
+            // gtag('set', 'u', { 'ads_data_redaction': !consents.marketing }); // Example if using data redaction
+        }
+    }
+
+    function createBanner() {
+        if (!settings.bannerEnabled) return;
+
+        document.body.insertAdjacentHTML('beforeend', `
+            <div id="dadecore-cookie-consent-banner">
+                <div class="cookie-banner-content">
+                    <div class="cookie-banner-text">
+                        <p>${settings.bannerText}</p>
+                    </div>
+                    <div class="cookie-banner-actions">
+                        <button id="dadecore-cookie-accept" class="accept">${settings.acceptText}</button>
+                        <button id="dadecore-cookie-decline" class="decline">${settings.declineText}</button>
+                        <button id="dadecore-cookie-settings" class="settings">${settings.settingsText}</button>
+                    </div>
+                </div>
+            </div>
+        `);
+        bannerElement = document.getElementById('dadecore-cookie-consent-banner');
+        bannerElement.style.display = 'block';
+
+        document.getElementById('dadecore-cookie-accept').addEventListener('click', handleAcceptAll);
+        document.getElementById('dadecore-cookie-decline').addEventListener('click', handleDeclineAll);
+        document.getElementById('dadecore-cookie-settings').addEventListener('click', openSettingsModal);
+    }
+
+    function destroyBanner() {
+        if (bannerElement) {
+            bannerElement.remove();
+            bannerElement = null;
+        }
+    }
+
+    function handleAcceptAll() {
+        const consents = {
+            necessary: true,
+            analytics: true,
+            marketing: true,
+            // ... any other categories set to true
+        };
+        setConsent(consents);
+        destroyBanner();
+        destroyModal(); // Ensure modal is also closed
+    }
+
+    function handleDeclineAll() {
+        const consents = {
+            necessary: true,
+            analytics: false,
+            marketing: false,
+            // ... any other categories set to false
+        };
+        setConsent(consents);
+        destroyBanner();
+        destroyModal(); // Ensure modal is also closed
+    }
+
+    function createModal() {
+        let categoriesHtml = '';
+        for (const key in settings.categories) {
+            if (settings.categories.hasOwnProperty(key)) {
+                const cat = settings.categories[key];
+                const isChecked = (key === 'necessary' || cat.currentConsent === true); // currentConsent will be populated when modal opens
+                const isDisabled = key === 'necessary';
+
+                categoriesHtml += `
+                    <div class="category">
+                        <div class="category-header">
+                            <label for="cookie-cat-${key}">${cat.label}</label>
+                            <label class="dadecore-cookie-toggle ${isDisabled ? 'disabled' : ''}">
+                                <input type="checkbox" id="cookie-cat-${key}" data-category="${key}" ${isChecked ? 'checked' : ''} ${isDisabled ? 'disabled' : ''}>
+                                <span class="slider"></span>
+                            </label>
+                        </div>
+                        <div class="category-description">
+                            ${cat.description}
+                        </div>
+                    </div>
+                `;
+            }
+        }
+
+        document.body.insertAdjacentHTML('beforeend', `
+            <div id="dadecore-cookie-settings-modal">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h3>${settings.bannerTitle || 'Cookie Settings'}</h3>
+                        <button class="modal-close-button" aria-label="Close">&times;</button>
+                    </div>
+                    <div class="modal-body">
+                        ${categoriesHtml}
+                    </div>
+                    <div class="modal-footer">
+                        <button id="dadecore-cookie-save-settings">${settings.saveSettingsText || 'Save Settings'}</button>
+                    </div>
+                </div>
+            </div>
+        `);
+
+        modalElement = document.getElementById('dadecore-cookie-settings-modal');
+        modalElement.style.display = 'flex';
+
+        modalElement.querySelector('.modal-close-button').addEventListener('click', closeSettingsModal);
+        document.getElementById('dadecore-cookie-save-settings').addEventListener('click', handleSaveSettings);
+
+        // Close modal if clicking outside the content
+        modalElement.addEventListener('click', function(event) {
+            if (event.target === modalElement) {
+                closeSettingsModal();
+            }
+        });
+    }
+
+    function destroyModal() {
+        if (modalElement) {
+            modalElement.remove();
+            modalElement = null;
+        }
+    }
+
+    function openSettingsModal() {
+        const currentConsent = getConsent() || defaultConsents; // Use existing or defaults
+        // Update settings object with current consent for checkboxes in modal
+        for (const key in settings.categories) {
+            if (settings.categories.hasOwnProperty(key)) {
+                settings.categories[key].currentConsent = currentConsent[key];
+            }
+        }
+        destroyBanner(); // Hide banner when modal is open
+        createModal();
+    }
+
+    function closeSettingsModal() {
+        destroyModal();
+        // Re-show banner if no consent has been given yet.
+        // If consent was already given and they just opened settings, don't reshow banner.
+        if (!getConsent()) {
+             createBanner();
+        }
+    }
+
+    function handleSaveSettings() {
+        const newConsents = { necessary: true }; // Necessary is always true
+        const checkboxes = modalElement.querySelectorAll('.modal-body input[type="checkbox"]');
+
+        checkboxes.forEach(checkbox => {
+            const category = checkbox.dataset.category;
+            if (category !== 'necessary') { // Necessary is handled above
+                newConsents[category] = checkbox.checked;
+            }
+        });
+
+        setConsent(newConsents);
+        destroyModal();
+        // No need to show banner again as settings are saved.
+    }
+
+    // --- Initialization ---
+    const existingConsent = getConsent();
+
+    if (!settings.bannerEnabled) {
+        // If banner is disabled in theme options, but GTM/Consent Mode is on,
+        // ensure GTM gets at least the default consent values (which it should on page load from PHP)
+        // Or, if there's existing consent, re-apply it for GTM.
+        if (existingConsent && settings.consentModeEnabled && typeof gtag === 'function') {
+            updateGtmConsent(existingConsent);
+        } else if (settings.consentModeEnabled && typeof gtag === 'function') {
+            // This ensures GTM is aware of the defaults if no consent has been given and banner is off
+            // However, the PHP part in header.php should already do this. This is a fallback.
+            const phpDefaults = {
+                analytics: settings.phpDefaultConsents.analytics_storage === 'granted',
+                marketing: settings.phpDefaultConsents.ad_storage === 'granted'
+            };
+            updateGtmConsent(phpDefaults);
+        }
+        return; // Do not proceed to show banner
+    }
+
+    if (!existingConsent) {
+        createBanner();
+    } else {
+        // Consent already exists, just ensure GTM is updated if Consent Mode is active
+        if (settings.consentModeEnabled && typeof gtag === 'function') {
+            updateGtmConsent(existingConsent);
+        }
+    }
+});

--- a/dadecore-theme/functions.php
+++ b/dadecore-theme/functions.php
@@ -32,4 +32,21 @@ function dadecore_register_elementor_locations( $elementor_theme_manager ) {
 }
 add_action( 'elementor/theme/register_locations', 'dadecore_register_elementor_locations' );
 */
+
+/**
+ * Add GTM noscript to wp_body_open.
+ */
+function dadecore_gtm_noscript() {
+    $gtm_id = get_theme_mod( 'dadecore_gtm_id' );
+    if ( ! empty( $gtm_id ) ) {
+        ?>
+        <!-- Google Tag Manager (noscript) -->
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<?php echo esc_attr( $gtm_id ); ?>"
+        height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+        <!-- End Google Tag Manager (noscript) -->
+        <?php
+    }
+}
+add_action( 'wp_body_open', 'dadecore_gtm_noscript' );
+
 ?>

--- a/dadecore-theme/header.php
+++ b/dadecore-theme/header.php
@@ -16,11 +16,49 @@
     <meta charset="<?php bloginfo( 'charset' ); ?>">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="profile" href="https://gmpg.org/xfn/11">
+    <?php
+    // GTM and Consent Mode Integration
+    $dadecore_gtm_id = get_theme_mod( 'dadecore_gtm_id' );
+    $dadecore_consent_mode_enabled = get_theme_mod( 'dadecore_consent_mode_enabled', false );
+
+    if ( ! empty( $dadecore_gtm_id ) ) : ?>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        <?php if ( $dadecore_consent_mode_enabled ) : ?>
+        gtag('consent', 'default', {
+            'ad_storage': '<?php echo esc_js( get_theme_mod( 'dadecore_default_consent_ad_storage', 'denied' ) ); ?>',
+            'analytics_storage': '<?php echo esc_js( get_theme_mod( 'dadecore_default_consent_analytics_storage', 'denied' ) ); ?>',
+            'functionality_storage': '<?php echo esc_js( get_theme_mod( 'dadecore_default_consent_functionality_storage', 'denied' ) ); ?>',
+            'personalization_storage': '<?php echo esc_js( get_theme_mod( 'dadecore_default_consent_personalization_storage', 'denied' ) ); ?>',
+            'security_storage': '<?php echo esc_js( get_theme_mod( 'dadecore_default_consent_security_storage', 'denied' ) ); ?>',
+            'wait_for_update': 500 // Optional: Adjust as needed
+        });
+        <?php
+            // Example of data redaction, can be expanded
+            if (get_theme_mod( 'dadecore_default_consent_ad_storage', 'denied' ) === 'denied') {
+                echo "gtag('set', 'ads_data_redaction', true);\n";
+            }
+        ?>
+        <?php endif; // end consent_mode_enabled ?>
+        // Fallback for dataLayer if GTM doesn't load (e.g. adblocker)
+        if (typeof gtag === 'undefined') {
+            function gtag() { console.warn('GTM not loaded, gtag calls will not be processed.'); dataLayer.push(arguments); }
+        }
+    </script>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','<?php echo esc_js( $dadecore_gtm_id ); ?>');</script>
+    <!-- End Google Tag Manager -->
+    <?php endif; // end !empty gtm_id ?>
     <?php wp_head(); ?>
 </head>
 
 <body <?php body_class(); ?>>
-<?php wp_body_open(); ?>
+<?php wp_body_open(); // Hook for GTM noscript and other body opening tags ?>
 <div id="page" class="site">
     <a class="skip-link screen-reader-text" href="#primary"><?php esc_html_e( 'Skip to content', 'dadecore' ); ?></a>
 

--- a/dadecore-theme/inc/customizer.php
+++ b/dadecore-theme/inc/customizer.php
@@ -4,7 +4,221 @@
  */
 
 function dadecore_customize_register( $wp_customize ) {
-    // Add customizer settings here
+    // Section for GTM and Cookie Settings
+    $wp_customize->add_section( 'dadecore_gtm_cookie_section', array(
+        'title'    => __( 'GTM & Cookie Consent', 'dadecore' ),
+        'priority' => 30,
+    ) );
+
+    // Google Tag Manager ID
+    $wp_customize->add_setting( 'dadecore_gtm_id', array(
+        'default'           => '',
+        'sanitize_callback' => 'sanitize_text_field',
+        'transport'         => 'refresh', // or postMessage
+    ) );
+    $wp_customize->add_control( 'dadecore_gtm_id_control', array(
+        'label'    => __( 'Google Tag Manager ID', 'dadecore' ),
+        'section'  => 'dadecore_gtm_cookie_section',
+        'settings' => 'dadecore_gtm_id',
+        'type'     => 'text',
+        'description' => __( 'Enter your GTM ID (e.g., GTM-XXXXXX).', 'dadecore' ),
+    ) );
+
+    // Enable Consent Mode v2
+    $wp_customize->add_setting( 'dadecore_consent_mode_enabled', array(
+        'default'           => false,
+        'sanitize_callback' => 'wp_validate_boolean',
+        'transport'         => 'refresh',
+    ) );
+    $wp_customize->add_control( 'dadecore_consent_mode_enabled_control', array(
+        'label'    => __( 'Enable Google Consent Mode v2', 'dadecore' ),
+        'section'  => 'dadecore_gtm_cookie_section',
+        'settings' => 'dadecore_consent_mode_enabled',
+        'type'     => 'checkbox',
+    ) );
+
+    // Default Consent States
+    $consent_types = array(
+        'ad_storage' => __( 'Ad Storage', 'dadecore' ),
+        'analytics_storage' => __( 'Analytics Storage', 'dadecore' ),
+        'functionality_storage' => __( 'Functionality Storage', 'dadecore' ),
+        'personalization_storage' => __( 'Personalization Storage', 'dadecore' ),
+        'security_storage' => __( 'Security Storage', 'dadecore' ),
+    );
+
+    foreach ( $consent_types as $slug => $label ) {
+        $wp_customize->add_setting( "dadecore_default_consent_{$slug}", array(
+            'default'           => 'denied',
+            'sanitize_callback' => 'dadecore_sanitize_consent_state',
+            'transport'         => 'refresh',
+        ) );
+        $wp_customize->add_control( "dadecore_default_consent_{$slug}_control", array(
+            'label'    => sprintf( __( 'Default %s State', 'dadecore' ), $label ),
+            'section'  => 'dadecore_gtm_cookie_section',
+            'settings' => "dadecore_default_consent_{$slug}",
+            'type'     => 'select',
+            'choices'  => array(
+                'denied'  => __( 'Denied', 'dadecore' ),
+                'granted' => __( 'Granted', 'dadecore' ),
+            ),
+            'description' => sprintf( __( 'Default state for %s when Consent Mode is enabled.', 'dadecore' ), $label ),
+        ) );
+    }
+
+    // --- Cookie Banner Settings ---
+
+    // Separator
+    $wp_customize->add_setting( 'dadecore_cookie_banner_separator', array(
+        'sanitize_callback' => 'esc_html', // No actual value, just for structure
+    ));
+    $wp_customize->add_control( new WP_Customize_Control( $wp_customize, 'dadecore_cookie_banner_separator_control', array(
+        'type' => 'hidden', // Will use customize_controls_print_styles to output HTML
+        'section' => 'dadecore_gtm_cookie_section',
+        'settings' => 'dadecore_cookie_banner_separator', // Dummy setting
+        'description' => '<hr style="margin-top: 20px; margin-bottom: 20px;"><h3>' . __( 'Cookie Consent Banner', 'dadecore' ) . '</h3>',
+    )));
+
+    // Enable Cookie Banner
+    $wp_customize->add_setting( 'dadecore_cookie_banner_enabled', array(
+        'default'           => false,
+        'sanitize_callback' => 'wp_validate_boolean',
+        'transport'         => 'refresh',
+    ) );
+    $wp_customize->add_control( 'dadecore_cookie_banner_enabled_control', array(
+        'label'    => __( 'Enable Cookie Consent Banner', 'dadecore' ),
+        'section'  => 'dadecore_gtm_cookie_section',
+        'settings' => 'dadecore_cookie_banner_enabled',
+        'type'     => 'checkbox',
+    ) );
+
+    // Banner Title
+    $wp_customize->add_setting( 'dadecore_cookie_banner_title', array(
+        'default'           => __( 'Cookie Consent', 'dadecore' ),
+        'sanitize_callback' => 'sanitize_text_field',
+        'transport'         => 'refresh',
+    ) );
+    $wp_customize->add_control( 'dadecore_cookie_banner_title_control', array(
+        'label'    => __( 'Banner Title', 'dadecore' ),
+        'section'  => 'dadecore_gtm_cookie_section',
+        'settings' => 'dadecore_cookie_banner_title',
+        'type'     => 'text',
+    ) );
+
+    // Banner Text
+    $wp_customize->add_setting( 'dadecore_cookie_banner_text', array(
+        'default'           => __( 'This website uses cookies to ensure you get the best experience on our website. Please accept cookies for optimal performance.', 'dadecore' ),
+        'sanitize_callback' => 'wp_kses_post', // Allows some HTML
+        'transport'         => 'refresh',
+    ) );
+    $wp_customize->add_control( 'dadecore_cookie_banner_text_control', array(
+        'label'    => __( 'Banner Text', 'dadecore' ),
+        'section'  => 'dadecore_gtm_cookie_section',
+        'settings' => 'dadecore_cookie_banner_text',
+        'type'     => 'textarea',
+    ) );
+
+    // Accept Button Text
+    $wp_customize->add_setting( 'dadecore_cookie_banner_accept_text', array(
+        'default'           => __( 'Accept All', 'dadecore' ),
+        'sanitize_callback' => 'sanitize_text_field',
+        'transport'         => 'refresh',
+    ) );
+    $wp_customize->add_control( 'dadecore_cookie_banner_accept_text_control', array(
+        'label'    => __( 'Accept Button Text', 'dadecore' ),
+        'section'  => 'dadecore_gtm_cookie_section',
+        'settings' => 'dadecore_cookie_banner_accept_text',
+        'type'     => 'text',
+    ) );
+
+    // Decline Button Text
+    $wp_customize->add_setting( 'dadecore_cookie_banner_decline_text', array(
+        'default'           => __( 'Decline', 'dadecore' ),
+        'sanitize_callback' => 'sanitize_text_field',
+        'transport'         => 'refresh',
+    ) );
+    $wp_customize->add_control( 'dadecore_cookie_banner_decline_text_control', array(
+        'label'    => __( 'Decline Button Text', 'dadecore' ),
+        'section'  => 'dadecore_gtm_cookie_section',
+        'settings' => 'dadecore_cookie_banner_decline_text',
+        'type'     => 'text',
+    ) );
+
+    // Settings Button Text
+    $wp_customize->add_setting( 'dadecore_cookie_banner_settings_text', array(
+        'default'           => __( 'Cookie Settings', 'dadecore' ),
+        'sanitize_callback' => 'sanitize_text_field',
+        'transport'         => 'refresh',
+    ) );
+    $wp_customize->add_control( 'dadecore_cookie_banner_settings_text_control', array(
+        'label'    => __( 'Settings Button Text', 'dadecore' ),
+        'section'  => 'dadecore_gtm_cookie_section',
+        'settings' => 'dadecore_cookie_banner_settings_text',
+        'type'     => 'text',
+    ) );
+
+    // Cookie Categories
+    // For simplicity, we'll define fixed categories and allow enabling/disabling and custom descriptions.
+    // A repeater control would be more flexible but adds complexity.
+    $cookie_categories = array(
+        'necessary' => array(
+            'label' => __( 'Necessary Cookies', 'dadecore' ),
+            'default_enabled' => true, // Necessary cookies are typically always enabled
+            'description' => __( 'These cookies are essential for the website to function properly. They are usually set in response to actions made by you, such as setting your privacy preferences, logging in, or filling in forms.', 'dadecore' )
+        ),
+        'analytics' => array(
+            'label' => __( 'Analytics Cookies', 'dadecore' ),
+            'default_enabled' => false,
+            'description' => __( 'These cookies allow us to count visits and traffic sources, so we can measure and improve the performance of our site. They help us know which pages are the most and least popular and see how visitors move around the site.', 'dadecore' )
+        ),
+        'marketing' => array(
+            'label' => __( 'Marketing Cookies', 'dadecore' ),
+            'default_enabled' => false,
+            'description' => __( 'These cookies may be set through our site by our advertising partners. They may be used by those companies to build a profile of your interests and show you relevant adverts on other sites.', 'dadecore' )
+        ),
+    );
+
+    foreach ( $cookie_categories as $slug => $cat ) {
+        // Enable/Disable Toggle (except for necessary)
+        if ( $slug !== 'necessary' ) {
+            $wp_customize->add_setting( "dadecore_cookie_cat_enabled_{$slug}", array(
+                'default'           => $cat['default_enabled'],
+                'sanitize_callback' => 'wp_validate_boolean',
+                'transport'         => 'refresh',
+            ) );
+            $wp_customize->add_control( "dadecore_cookie_cat_enabled_{$slug}_control", array(
+                'label'    => sprintf( __( 'Enable %s', 'dadecore' ), $cat['label'] ),
+                'section'  => 'dadecore_gtm_cookie_section',
+                'settings' => "dadecore_cookie_cat_enabled_{$slug}",
+                'type'     => 'checkbox',
+            ) );
+        }
+
+        // Description Textarea
+        $wp_customize->add_setting( "dadecore_cookie_cat_desc_{$slug}", array(
+            'default'           => $cat['description'],
+            'sanitize_callback' => 'wp_kses_post',
+            'transport'         => 'refresh',
+        ) );
+        $wp_customize->add_control( "dadecore_cookie_cat_desc_{$slug}_control", array(
+            'label'    => sprintf( __( '%s Description', 'dadecore' ), $cat['label'] ),
+            'section'  => 'dadecore_gtm_cookie_section',
+            'settings' => "dadecore_cookie_cat_desc_{$slug}",
+            'type'     => 'textarea',
+        ) );
+    }
+    // Add other customizer settings here
 }
 add_action( 'customize_register', 'dadecore_customize_register' );
+
+/**
+ * Sanitize consent state.
+ */
+function dadecore_sanitize_consent_state( $input ) {
+    $valid = array( 'denied', 'granted' );
+    if ( in_array( $input, $valid, true ) ) {
+        return $input;
+    }
+    return 'denied';
+}
+
 ?>

--- a/dadecore-theme/inc/enqueue.php
+++ b/dadecore-theme/inc/enqueue.php
@@ -7,6 +7,52 @@ function dadecore_scripts() {
     wp_enqueue_style( 'dadecore-style', get_stylesheet_uri(), array(), '1.0' );
     wp_enqueue_style( 'dadecore-custom-styles', get_template_directory_uri() . '/assets/css/custom-styles.css', array('dadecore-style'), filemtime(get_template_directory() . '/assets/css/custom-styles.css') );
     wp_enqueue_script( 'dadecore-script', get_template_directory_uri() . '/assets/js/main.js', array( 'jquery' ), '1.0', true );
+
+    // Cookie Consent Banner Assets
+    if ( get_theme_mod( 'dadecore_cookie_banner_enabled', false ) ) {
+        wp_enqueue_style( 'dadecore-cookie-banner-style', get_template_directory_uri() . '/assets/css/cookie-banner.css', array('dadecore-style'), filemtime(get_template_directory() . '/assets/css/cookie-banner.css') );
+        wp_enqueue_script( 'dadecore-cookie-consent-script', get_template_directory_uri() . '/assets/js/cookie-consent.js', array(), filemtime(get_template_directory() . '/assets/js/cookie-consent.js'), true );
+
+        // Localize script with settings
+        $cookie_categories_settings = array();
+        $defined_categories = array( // Should match those in customizer.php
+            'necessary' => array( 'label' => get_theme_mod('dadecore_cookie_cat_label_necessary', __( 'Necessary Cookies', 'dadecore' )), 'defaultEnabled' => true ), // Default label, actual description from customizer
+            'analytics' => array( 'label' => get_theme_mod('dadecore_cookie_cat_label_analytics', __( 'Analytics Cookies', 'dadecore' )), 'defaultEnabled' => get_theme_mod('dadecore_cookie_cat_enabled_analytics', false) ),
+            'marketing' => array( 'label' => get_theme_mod('dadecore_cookie_cat_label_marketing', __( 'Marketing Cookies', 'dadecore' )), 'defaultEnabled' => get_theme_mod('dadecore_cookie_cat_enabled_marketing', false) ),
+        );
+
+        foreach ( $defined_categories as $slug => $cat_defaults ) {
+            // Only add category if it's 'necessary' or enabled in customizer
+            if ( $slug === 'necessary' || get_theme_mod( "dadecore_cookie_cat_enabled_{$slug}", $cat_defaults['defaultEnabled'] ) ) {
+                 $cookie_categories_settings[$slug] = array(
+                    'label' => get_theme_mod( "dadecore_cookie_cat_label_{$slug}", $cat_defaults['label'] ), // This customizer field doesn't exist yet, using default. Actual label for display is in customizer desc.
+                    'description' => get_theme_mod( "dadecore_cookie_cat_desc_{$slug}", '' ), // Fetch from customizer
+                    'defaultEnabled' => ($slug === 'necessary') ? true : get_theme_mod( "dadecore_cookie_cat_enabled_{$slug}", $cat_defaults['defaultEnabled'] ),
+                );
+            }
+        }
+
+        // Get PHP default consent states to pass to JS (for fallback if banner is off but GTM is on)
+        $php_default_consents = array(
+            'ad_storage' => get_theme_mod( 'dadecore_default_consent_ad_storage', 'denied' ),
+            'analytics_storage' => get_theme_mod( 'dadecore_default_consent_analytics_storage', 'denied' ),
+            // Add other GCM types if you have corresponding theme options
+        );
+
+        wp_localize_script( 'dadecore-cookie-consent-script', 'dadecoreCookieConsent', array(
+            'bannerEnabled'         => get_theme_mod( 'dadecore_cookie_banner_enabled', false ),
+            'bannerTitle'           => get_theme_mod( 'dadecore_cookie_banner_title', __( 'Cookie Consent', 'dadecore' ) ),
+            'bannerText'            => wp_kses_post( get_theme_mod( 'dadecore_cookie_banner_text', '' ) ),
+            'acceptText'            => get_theme_mod( 'dadecore_cookie_banner_accept_text', __( 'Accept All', 'dadecore' ) ),
+            'declineText'           => get_theme_mod( 'dadecore_cookie_banner_decline_text', __( 'Decline', 'dadecore' ) ),
+            'settingsText'          => get_theme_mod( 'dadecore_cookie_banner_settings_text', __( 'Cookie Settings', 'dadecore' ) ),
+            'saveSettingsText'      => __( 'Save Settings', 'dadecore' ), // This text is not in customizer yet, adding directly
+            'categories'            => $cookie_categories_settings,
+            'gtmId'                 => get_theme_mod( 'dadecore_gtm_id', '' ),
+            'consentModeEnabled'    => get_theme_mod( 'dadecore_consent_mode_enabled', false ),
+            'phpDefaultConsents'    => $php_default_consents
+        ) );
+    }
 }
 add_action( 'wp_enqueue_scripts', 'dadecore_scripts' );
 ?>


### PR DESCRIPTION
- Added theme options in Customizer for Google Tag Manager ID and Consent Mode v2 default states.
- Integrated GTM script loading in header.php, including default consent command and noscript iframe via wp_body_open.
- Ensured SEO plugin compatibility by verifying wp_head, title-tag support, and absence of conflicting theme meta tags.
- Implemented a cookie consent banner with backend options for texts and cookie categories (Necessary, Analytics, Marketing).
- Created cookie-banner.css for styling and cookie-consent.js for frontend logic (display, interaction, localStorage consent storage, GTM consent updates).
- Enqueued cookie banner assets and localized script with settings from Customizer.
- Outlined comprehensive manual testing procedures.