### PR TITLE
Fix Elementor check in templates

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -1,5 +1,5 @@
 <?php
-if ( ! elementor_theme_do_location( 'single' ) ) {
+if ( ! function_exists( 'elementor_theme_do_location' ) || ! elementor_theme_do_location( 'single' ) ) {
     get_header();
     if ( have_posts() ) {
         while ( have_posts() ) {

--- a/page.php
+++ b/page.php
@@ -1,5 +1,5 @@
 <?php
-if ( ! elementor_theme_do_location( 'single' ) ) {
+if ( ! function_exists( 'elementor_theme_do_location' ) || ! elementor_theme_do_location( 'single' ) ) {
     get_header();
     while ( have_posts() ) {
         the_post();

--- a/single.php
+++ b/single.php
@@ -1,5 +1,5 @@
 <?php
-if ( ! elementor_theme_do_location( 'single' ) ) {
+if ( ! function_exists( 'elementor_theme_do_location' ) || ! elementor_theme_do_location( 'single' ) ) {
     get_header();
     while ( have_posts() ) {
         the_post();


### PR DESCRIPTION
## Summary
- prevent errors when Elementor isn't installed
- update `front-page.php`, `page.php` and `single.php`

## Testing
- `php -l front-page.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68648c022214832fae0b72ef356df98f