### PR TITLE
Add SCSS styles and enqueue compiled CSS

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -31,13 +31,46 @@
 }
 
 body {
-  font-family: sans-serif;
+  font-family: 'Inter', sans-serif;
   line-height: 1.6;
-  color: #333;
+  color: var(--wp--preset--color--gris-oscuro, #333);
+  background-color: var(--wp--preset--color--light, #fff);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Poppins', sans-serif;
+  line-height: 1.2;
+  margin-bottom: 0.5rem;
 }
 
 .container {
   width: 90%;
-  max-width: 1100px;
+  max-width: 1200px;
   margin: 0 auto;
+}
+
+@media (min-width: 768px) {
+  .container {
+    width: 85%;
+  }
+}
+
+@media (min-width: 992px) {
+  .container {
+    width: 80%;
+  }
+}
+
+.btn {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border-radius: var(--wp--preset--radius--medium, 0.5rem);
+  background-color: var(--wp--preset--color--primary);
+  color: var(--wp--preset--color--light);
+  text-decoration: none;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.btn:hover {
+  background-color: var(--wp--preset--color--secondary);
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -3,21 +3,60 @@
 // Import WooCommerce styles
 @import 'woocommerce';
 
-// You can add other theme-specific SCSS imports or rules below
-// For example:
-// @import 'variables';
-// @import 'layout';
-// @import 'components/buttons';
-// @import 'pages/home';
+// Breakpoints from theme.json
+$breakpoints: (
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px
+);
 
-body {
-  font-family: sans-serif;
-  line-height: 1.6;
-  color: #333;
+@mixin respond-to($size) {
+  @media (min-width: map-get($breakpoints, $size)) {
+    @content;
+  }
 }
 
+// Typography
+body {
+  font-family: 'Inter', sans-serif;
+  line-height: 1.6;
+  color: var(--wp--preset--color--gris-oscuro, #333);
+  background-color: var(--wp--preset--color--light, #fff);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Poppins', sans-serif;
+  line-height: 1.2;
+  margin-bottom: 0.5rem;
+}
+
+// Layout
 .container {
   width: 90%;
-  max-width: 1100px;
+  max-width: map-get($breakpoints, xl);
   margin: 0 auto;
+
+  @include respond-to(md) {
+    width: 85%;
+  }
+
+  @include respond-to(lg) {
+    width: 80%;
+  }
+}
+
+// Components
+.btn {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border-radius: var(--wp--preset--radius--medium, 0.5rem);
+  background-color: var(--wp--preset--color--primary);
+  color: var(--wp--preset--color--light);
+  text-decoration: none;
+  transition: background-color 0.2s ease-in-out;
+
+  &:hover {
+    background-color: var(--wp--preset--color--secondary);
+  }
 }

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -4,19 +4,37 @@
  */
 
 function dadecore_scripts() {
-    wp_enqueue_style( 'dadecore-style', get_stylesheet_uri(), array(), '1.0' ); // This usually refers to the theme's style.css in the root of the theme.
-
-    // Enqueue your new compiled SCSS file
+    // Base stylesheet loaded by WordPress
     wp_enqueue_style(
-        'dadecore-main-styles', // New handle for your main compiled SCSS
-        get_template_directory_uri() . '/assets/css/style.css', // Path to your compiled style.css
-        array('dadecore-style'), // Potentially depends on the base 'dadecore-style'
-        filemtime(get_template_directory() . '/assets/css/style.css') // Versioning using file modification time
+        'dadecore-style',
+        get_stylesheet_uri(),
+        array(),
+        '1.0'
     );
 
-    wp_enqueue_style( 'dadecore-custom-styles', get_template_directory_uri() . '/assets/css/custom-styles.css', array('dadecore-main-styles'), filemtime(get_template_directory() . '/assets/css/custom-styles.css') ); // Make custom-styles depend on main-styles
+    // Compiled SCSS output
+    wp_enqueue_style(
+        'dadecore-main-styles',
+        get_template_directory_uri() . '/assets/css/style.css',
+        array( 'dadecore-style' ),
+        filemtime( get_template_directory() . '/assets/css/style.css' )
+    );
 
-    wp_enqueue_script( 'dadecore-script', get_template_directory_uri() . '/assets/js/main.js', array( 'jquery' ), '1.0', true );
+    // Optional custom overrides
+    wp_enqueue_style(
+        'dadecore-custom-styles',
+        get_template_directory_uri() . '/assets/css/custom-styles.css',
+        array( 'dadecore-main-styles' ),
+        filemtime( get_template_directory() . '/assets/css/custom-styles.css' )
+    );
+
+    wp_enqueue_script(
+        'dadecore-script',
+        get_template_directory_uri() . '/assets/js/main.js',
+        array( 'jquery' ),
+        '1.0',
+        true
+    );
 }
 add_action( 'wp_enqueue_scripts', 'dadecore_scripts' );
 ?>


### PR DESCRIPTION
## Summary
- add layout variables and global typography to `style.scss`
- compile SCSS to `style.css`
- tidy up `inc/enqueue.php` and enqueue the compiled CSS

## Testing
- `npx sass assets/css/style.scss assets/css/style.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68649f584114832f880fb147a8ab75ae