### PR TITLE
Add Customizer controls for theme

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -4,7 +4,147 @@
  */
 
 function dadecore_customize_register( $wp_customize ) {
-    // Add customizer settings here
+    // Load options from theme.json so defaults stay in sync
+    $json    = json_decode( file_get_contents( get_template_directory() . '/theme.json' ), true );
+    $options = isset( $json['settings'] ) ? $json['settings'] : array();
+
+    /* ------------------------------------ COLORS ------------------------------------ */
+    // Create color controls based on the palette defined in theme.json
+    if ( ! empty( $options['color']['palette'] ) ) {
+        foreach ( $options['color']['palette'] as $color ) {
+            $slug  = $color['slug'];
+            $label = $color['name'];
+
+            // Setting stores the selected color for the slug
+            $wp_customize->add_setting( "palette_{$slug}", array(
+                'default'           => $color['color'],
+                'sanitize_callback' => 'sanitize_hex_color',
+            ) );
+
+            // Color picker control for the palette color
+            $wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, "palette_{$slug}", array(
+                'label'   => sprintf( __( '%s Color', 'dadecore' ), $label ),
+                'section' => 'colors',
+            ) ) );
+        }
+    }
+
+    /* ---------------------------------- TYPOGRAPHY --------------------------------- */
+    $wp_customize->add_section( 'dadecore_typography', array(
+        'title' => __( 'Typography', 'dadecore' ),
+    ) );
+
+    if ( ! empty( $options['typography']['fontFamilies'] ) ) {
+        // Map slugs to readable names for the font family select
+        $fonts        = array();
+        $default_font = '';
+        foreach ( $options['typography']['fontFamilies'] as $index => $font ) {
+            $fonts[ $font['slug'] ] = $font['name'];
+            if ( 0 === $index ) {
+                $default_font = $font['slug'];
+            }
+        }
+
+        // Chosen font family for body text
+        $wp_customize->add_setting( 'font_family', array(
+            'default'           => $default_font,
+            'sanitize_callback' => 'sanitize_text_field',
+        ) );
+
+        $wp_customize->add_control( 'font_family', array(
+            'label'   => __( 'Font Family', 'dadecore' ),
+            'section' => 'dadecore_typography',
+            'type'    => 'select',
+            'choices' => $fonts,
+        ) );
+    }
+
+    if ( ! empty( $options['typography']['fontSizes'] ) ) {
+        // Map slugs to names for the base size select
+        $sizes        = array();
+        $default_size = '';
+        foreach ( $options['typography']['fontSizes'] as $index => $size ) {
+            $sizes[ $size['slug'] ] = $size['name'];
+            if ( 'regular' === $size['slug'] ) {
+                $default_size = $size['slug'];
+            }
+        }
+
+        // Base font size slug
+        $wp_customize->add_setting( 'font_size', array(
+            'default'           => $default_size,
+            'sanitize_callback' => 'sanitize_text_field',
+        ) );
+
+        $wp_customize->add_control( 'font_size', array(
+            'label'   => __( 'Base Font Size', 'dadecore' ),
+            'section' => 'dadecore_typography',
+            'type'    => 'select',
+            'choices' => $sizes,
+        ) );
+    }
+
+    /* ------------------------------------ LAYOUT ------------------------------------ */
+    $wp_customize->add_section( 'dadecore_layout', array(
+        'title' => __( 'Layout', 'dadecore' ),
+    ) );
+
+    $content_default = isset( $options['layout']['contentSize'] ) ? $options['layout']['contentSize'] : '800px';
+    $wide_default    = isset( $options['layout']['wideSize'] ) ? $options['layout']['wideSize'] : '1200px';
+
+    // Width for normal content area
+    $wp_customize->add_setting( 'content_width', array(
+        'default'           => $content_default,
+        'sanitize_callback' => 'sanitize_text_field',
+    ) );
+    $wp_customize->add_control( 'content_width', array(
+        'label'   => __( 'Content Width', 'dadecore' ),
+        'section' => 'dadecore_layout',
+        'type'    => 'text',
+    ) );
+
+    // Width for wide blocks
+    $wp_customize->add_setting( 'wide_width', array(
+        'default'           => $wide_default,
+        'sanitize_callback' => 'sanitize_text_field',
+    ) );
+    $wp_customize->add_control( 'wide_width', array(
+        'label'   => __( 'Wide Width', 'dadecore' ),
+        'section' => 'dadecore_layout',
+        'type'    => 'text',
+    ) );
+
+    /* ---------------------------- HEADER & FOOTER SETTINGS --------------------------- */
+    $wp_customize->add_section( 'dadecore_header', array(
+        'title'    => __( 'Header', 'dadecore' ),
+        'priority' => 30,
+    ) );
+
+    // Background color for the site header
+    $wp_customize->add_setting( 'header_background_color', array(
+        'default'           => '#ffffff',
+        'sanitize_callback' => 'sanitize_hex_color',
+    ) );
+    $wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'header_background_color', array(
+        'label'   => __( 'Header Background Color', 'dadecore' ),
+        'section' => 'dadecore_header',
+    ) ) );
+
+    $wp_customize->add_section( 'dadecore_footer', array(
+        'title'    => __( 'Footer', 'dadecore' ),
+        'priority' => 40,
+    ) );
+
+    // Text displayed in the footer area
+    $wp_customize->add_setting( 'footer_text', array(
+        'default'           => '',
+        'sanitize_callback' => 'sanitize_text_field',
+    ) );
+    $wp_customize->add_control( 'footer_text', array(
+        'label'   => __( 'Footer Text', 'dadecore' ),
+        'section' => 'dadecore_footer',
+        'type'    => 'text',
+    ) );
 }
 add_action( 'customize_register', 'dadecore_customize_register' );
 ?>

--- a/inc/setup.php
+++ b/inc/setup.php
@@ -24,8 +24,12 @@ function dadecore_theme_setup() {
     // Switch default core markup for search form, comment form, and comments
     add_theme_support( 'html5', array( 'search-form', 'comment-form', 'comment-list', 'gallery', 'caption' ) );
 
-    // Custom logo support
+    // Custom logo support so users can upload their brand mark
     add_theme_support( 'custom-logo' );
+
+    // Enable WordPress core header and background customization
+    add_theme_support( 'custom-header' );
+    add_theme_support( 'custom-background' );
 
     // WooCommerce support
     add_theme_support( 'woocommerce' );

--- a/template-parts/footer/site-footer.php
+++ b/template-parts/footer/site-footer.php
@@ -1,5 +1,9 @@
+<?php
+// Customizable footer text set from the Customizer
+$footer_text = get_theme_mod( 'footer_text', sprintf( esc_html__( 'Proudly powered by %s', 'dadecore' ), 'WordPress' ) );
+?>
 <footer id="colophon" class="site-footer">
     <div class="site-info">
-        <?php printf( esc_html__( 'Proudly powered by %s', 'dadecore' ), 'WordPress' ); ?>
+        <?php echo esc_html( $footer_text ); ?>
     </div>
 </footer>

--- a/template-parts/header/site-header.php
+++ b/template-parts/header/site-header.php
@@ -1,4 +1,8 @@
-<header id="masthead" class="site-header">
+<?php
+// Allow users to change the header color from the Customizer
+$header_bg = get_theme_mod( 'header_background_color', '#ffffff' );
+?>
+<header id="masthead" class="site-header" style="background-color: <?php echo esc_attr( $header_bg ); ?>;">
     <div class="site-branding">
         <?php the_custom_logo(); ?>
         <div class="site-title-description">


### PR DESCRIPTION
## Summary
- register palette, font, and layout settings based on `theme.json`
- expose header color and footer text settings in the Customizer
- enable custom header and background support
- render new header background color and footer text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864a0a49c7c832fbff3f5096000443c