### PR TITLE
Add security headers and login protections

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,13 @@ Make sure the generated CSS files are available in the theme before activating i
 - JavaScript enhancements can be added in `assets/js/main.js`.
 
 Feel free to adapt the theme to your needs and extend it with additional features.
+
+## Security Features
+
+This theme ships with a few basic security improvements:
+
+- A filter that changes the login URL slug (default `/login/`).
+- Simple rate limiting for failed login attempts.
+- Automatic security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`).
+
+You can adjust the login slug, the allowed attempts and the lockout duration under **Appearance → DadeCore Options → Login Security**. The login attempt limiter is disabled when a security plugin such as Wordfence is detected so there are no hook conflicts.

--- a/inc/security.php
+++ b/inc/security.php
@@ -3,5 +3,100 @@
  * Basic security enhancements
  */
 
-// Placeholder for security tweaks
-?>
+// Custom login slug and simple login attempt limiting.
+// Skip these hooks if Wordfence or similar security plugin defines WORDFENCE_VERSION.
+
+if ( ! defined( 'WORDFENCE_VERSION' ) ) {
+    /**
+     * Serve wp-login.php from a custom slug.
+     */
+    function dadecore_login_rewrite() {
+        $options      = get_option( 'dadecore_options', array() );
+        $slug         = isset( $options['login_slug'] ) ? sanitize_title( $options['login_slug'] ) : 'login';
+        $request_path = trim( parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ), '/' );
+
+        if ( $request_path === $slug ) {
+            require_once ABSPATH . 'wp-login.php';
+            exit;
+        }
+
+        if ( ! is_user_logged_in() && ( $request_path === 'wp-login.php' || strpos( $request_path, 'wp-admin' ) === 0 ) ) {
+            global $wp_query;
+            $wp_query->set_404();
+            status_header( 404 );
+            nocache_headers();
+            include get_query_template( '404' );
+            exit;
+        }
+    }
+    add_action( 'init', 'dadecore_login_rewrite' );
+
+    /**
+     * Filter login URLs to use the custom slug.
+     */
+    function dadecore_filter_login_url( $login_url, $redirect, $force_reauth ) {
+        $options   = get_option( 'dadecore_options', array() );
+        $slug      = isset( $options['login_slug'] ) ? sanitize_title( $options['login_slug'] ) : 'login';
+        $login_url = home_url( '/' . $slug . '/' );
+        if ( $redirect ) {
+            $login_url = add_query_arg( 'redirect_to', urlencode( $redirect ), $login_url );
+        }
+        if ( $force_reauth ) {
+            $login_url = add_query_arg( 'reauth', '1', $login_url );
+        }
+        return $login_url;
+    }
+    add_filter( 'login_url', 'dadecore_filter_login_url', 10, 3 );
+
+    /**
+     * Limit failed login attempts per IP address.
+     */
+    function dadecore_limit_login_attempts( $user, $username, $password ) {
+        if ( $user instanceof WP_User ) {
+            $key = 'dadecore_login_attempts_' . md5( $_SERVER['REMOTE_ADDR'] );
+            delete_transient( $key );
+            return $user;
+        }
+
+        $options  = get_option( 'dadecore_options', array() );
+        $limit    = isset( $options['login_attempts'] ) ? absint( $options['login_attempts'] ) : 3;
+        $duration = isset( $options['lockout_minutes'] ) ? absint( $options['lockout_minutes'] ) : 15;
+
+        $key      = 'dadecore_login_attempts_' . md5( $_SERVER['REMOTE_ADDR'] );
+        $attempts = (int) get_transient( $key );
+
+        if ( $attempts >= $limit ) {
+            return new WP_Error( 'too_many_attempts', __( '<strong>Error</strong>: Too many login attempts. Please try again later.' ) );
+        }
+
+        set_transient( $key, $attempts + 1, $duration * MINUTE_IN_SECONDS );
+        return $user;
+    }
+    add_filter( 'authenticate', 'dadecore_limit_login_attempts', 30, 3 );
+}
+
+/**
+ * Send security headers if they are not already present.
+ */
+function dadecore_send_security_headers() {
+    if ( headers_sent() ) {
+        return;
+    }
+
+    $existing = array();
+    foreach ( headers_list() as $header ) {
+        list( $name ) = explode( ':', $header, 2 );
+        $existing[] = trim( $name );
+    }
+
+    if ( ! in_array( 'X-Frame-Options', $existing, true ) ) {
+        header( 'X-Frame-Options: SAMEORIGIN' );
+    }
+    if ( ! in_array( 'X-Content-Type-Options', $existing, true ) ) {
+        header( 'X-Content-Type-Options: nosniff' );
+    }
+    if ( ! in_array( 'Referrer-Policy', $existing, true ) ) {
+        header( 'Referrer-Policy: same-origin' );
+    }
+}
+add_action( 'send_headers', 'dadecore_send_security_headers' );

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -18,9 +18,12 @@ function dadecore_register_theme_options() {
             'type'              => 'array',
             'sanitize_callback' => 'dadecore_sanitize_options',
             'default'           => array(
-                'adsense_code'  => '',
-                'amazon_block'  => '',
-                'gtm_container' => '',
+                'adsense_code'    => '',
+                'amazon_block'    => '',
+                'gtm_container'   => '',
+                'login_slug'      => 'login',
+                'login_attempts'  => 3,
+                'lockout_minutes' => 15,
             ),
         )
     );
@@ -55,6 +58,37 @@ function dadecore_register_theme_options() {
         'dadecore_options',
         'dadecore_ads_section'
     );
+
+    add_settings_section(
+        'dadecore_security_section',
+        __( 'Login Security', 'dadecore' ),
+        '__return_false',
+        'dadecore_options'
+    );
+
+    add_settings_field(
+        'dadecore_login_slug',
+        __( 'Login Slug', 'dadecore' ),
+        'dadecore_login_slug_field',
+        'dadecore_options',
+        'dadecore_security_section'
+    );
+
+    add_settings_field(
+        'dadecore_login_attempts',
+        __( 'Allowed Login Attempts', 'dadecore' ),
+        'dadecore_login_attempts_field',
+        'dadecore_options',
+        'dadecore_security_section'
+    );
+
+    add_settings_field(
+        'dadecore_lockout_minutes',
+        __( 'Lockout Minutes', 'dadecore' ),
+        'dadecore_lockout_minutes_field',
+        'dadecore_options',
+        'dadecore_security_section'
+    );
 }
 add_action( 'admin_init', 'dadecore_register_theme_options' );
 
@@ -69,6 +103,9 @@ function dadecore_sanitize_options( $input ) {
     $output['adsense_code']  = isset( $input['adsense_code'] ) ? wp_kses_post( $input['adsense_code'] ) : '';
     $output['amazon_block']  = isset( $input['amazon_block'] ) ? wp_kses_post( $input['amazon_block'] ) : '';
     $output['gtm_container'] = isset( $input['gtm_container'] ) ? sanitize_text_field( $input['gtm_container'] ) : '';
+    $output['login_slug']      = isset( $input['login_slug'] ) ? sanitize_title( $input['login_slug'] ) : 'login';
+    $output['login_attempts']  = isset( $input['login_attempts'] ) ? absint( $input['login_attempts'] ) : 3;
+    $output['lockout_minutes'] = isset( $input['lockout_minutes'] ) ? absint( $input['lockout_minutes'] ) : 15;
 
     return $output;
 }
@@ -111,6 +148,45 @@ function dadecore_gtm_field() {
     printf(
         '<input type="text" name="dadecore_options[gtm_container]" value="%s" class="regular-text" />',
         esc_attr( $gtm_container )
+    );
+}
+
+/**
+ * Output input field for the login slug.
+ */
+function dadecore_login_slug_field() {
+    $options    = get_option( 'dadecore_options', array() );
+    $login_slug = isset( $options['login_slug'] ) ? $options['login_slug'] : 'login';
+
+    printf(
+        '<input type="text" name="dadecore_options[login_slug]" value="%s" class="regular-text" />',
+        esc_attr( $login_slug )
+    );
+}
+
+/**
+ * Output input field for allowed login attempts.
+ */
+function dadecore_login_attempts_field() {
+    $options         = get_option( 'dadecore_options', array() );
+    $login_attempts  = isset( $options['login_attempts'] ) ? (int) $options['login_attempts'] : 3;
+
+    printf(
+        '<input type="number" name="dadecore_options[login_attempts]" value="%d" class="small-text" min="1" />',
+        $login_attempts
+    );
+}
+
+/**
+ * Output input field for lockout duration in minutes.
+ */
+function dadecore_lockout_minutes_field() {
+    $options         = get_option( 'dadecore_options', array() );
+    $lockout_minutes = isset( $options['lockout_minutes'] ) ? (int) $options['lockout_minutes'] : 15;
+
+    printf(
+        '<input type="number" name="dadecore_options[lockout_minutes]" value="%d" class="small-text" min="1" />',
+        $lockout_minutes
     );
 }
 


### PR DESCRIPTION
## Summary
- implement new security features in `inc/security.php`
- document security features in README
- make login security options configurable via theme options

## Testing
- `php -l inc/security.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a467df88832fbc0dbc4d820ff2ff