### PR TITLE
Add cookie banner and consent mode

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -74,3 +74,18 @@ h1, h2, h3, h4, h5, h6 {
 .btn:hover {
   background-color: var(--wp--preset--color--secondary);
 }
+#cookie-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 1rem;
+  background: #222;
+  color: #fff;
+  text-align: center;
+  z-index: 9999;
+  display: none;
+}
+#cookie-banner button {
+  margin-left: 0.5rem;
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -60,3 +60,20 @@ h1, h2, h3, h4, h5, h6 {
     background-color: var(--wp--preset--color--secondary);
   }
 }
+
+#cookie-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 1rem;
+  background: #222;
+  color: #fff;
+  text-align: center;
+  z-index: 9999;
+  display: none;
+
+  button {
+    margin-left: 0.5rem;
+  }
+}

--- a/assets/js/cookie-banner.js
+++ b/assets/js/cookie-banner.js
@@ -1,0 +1,38 @@
+(function(){
+    function updateConsent(granted){
+        if (typeof gtag === 'function') {
+            gtag('consent', 'update', {
+                'ad_storage': granted ? 'granted' : 'denied',
+                'analytics_storage': granted ? 'granted' : 'denied',
+                'ad_user_data': granted ? 'granted' : 'denied',
+                'ad_personalization': granted ? 'granted' : 'denied'
+            });
+        }
+        if(granted){
+            var ev = document.createEvent('Event');
+            ev.initEvent('cookies-consent-granted', true, true);
+            document.dispatchEvent(ev);
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function(){
+        var stored = localStorage.getItem('cookieConsent');
+        if(stored){
+            updateConsent(stored === 'granted');
+            return;
+        }
+        var banner = document.getElementById('cookie-banner');
+        if(!banner) return;
+        banner.style.display = 'block';
+        banner.querySelector('.cookie-accept').addEventListener('click', function(){
+            banner.style.display = 'none';
+            localStorage.setItem('cookieConsent','granted');
+            updateConsent(true);
+        });
+        banner.querySelector('.cookie-decline').addEventListener('click', function(){
+            banner.style.display = 'none';
+            localStorage.setItem('cookieConsent','denied');
+            updateConsent(false);
+        });
+    });
+})();

--- a/functions.php
+++ b/functions.php
@@ -10,6 +10,7 @@ require_once get_template_directory() . '/inc/customizer.php';
 require_once get_template_directory() . '/inc/theme-options.php';
 require_once get_template_directory() . '/inc/security.php';
 require_once get_template_directory() . '/inc/seo-metadata.php';
+require_once get_template_directory() . '/inc/consent.php';
 
 // Elementor locations
 // La siguiente función y acción registran las ubicaciones del tema central de WordPress (header, footer, archive, single)

--- a/inc/consent.php
+++ b/inc/consent.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Cookie banner and consent handling.
+ */
+
+/**
+ * Output Google Consent Mode default settings.
+ */
+function dadecore_output_consent_mode() {
+    $options = get_option( 'dadecore_options', array() );
+    if ( ! empty( $options['disable_gcm'] ) ) {
+        return;
+    }
+    ?>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('consent','default',{
+        'ad_storage':'denied',
+        'analytics_storage':'denied',
+        'ad_user_data':'denied',
+        'ad_personalization':'denied',
+        'wait_for_update':500
+    });
+    </script>
+    <?php
+}
+add_action( 'wp_head', 'dadecore_output_consent_mode' );
+
+/**
+ * Load Google Tag Manager after consent.
+ */
+function dadecore_output_gtm_script() {
+    $options = get_option( 'dadecore_options', array() );
+    $container = isset( $options['gtm_container'] ) ? trim( $options['gtm_container'] ) : '';
+    if ( ! $container ) {
+        return;
+    }
+    ?>
+    <script>
+    function dadecore_load_gtm(){
+        if(window.dadecore_gtm_loaded) return;
+        window.dadecore_gtm_loaded = true;
+        var f=document.getElementsByTagName('script')[0];
+        var j=document.createElement('script');
+        j.async=true;
+        j.src='https://www.googletagmanager.com/gtm.js?id=<?php echo esc_js( $container ); ?>';
+        f.parentNode.insertBefore(j,f);
+    }
+    if(localStorage.getItem('cookieConsent')==='granted'){
+        dadecore_load_gtm();
+    }else{
+        document.addEventListener('cookies-consent-granted', dadecore_load_gtm);
+    }
+    </script>
+    <?php
+}
+add_action( 'wp_head', 'dadecore_output_gtm_script', 20 );
+
+function dadecore_output_gtm_noscript() {
+    $options = get_option( 'dadecore_options', array() );
+    $container = isset( $options['gtm_container'] ) ? trim( $options['gtm_container'] ) : '';
+    if ( ! $container ) {
+        return;
+    }
+    echo '<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=' . esc_attr( $container ) . '" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>';
+}
+add_action( 'wp_body_open', 'dadecore_output_gtm_noscript' );
+
+/**
+ * Display the cookie banner markup.
+ */
+function dadecore_cookie_banner_markup() {
+    ?>
+    <div id="cookie-banner">
+        <span><?php echo esc_html__( 'We use cookies to improve your experience.', 'dadecore' ); ?></span>
+        <button class="cookie-accept"><?php echo esc_html__( 'Accept', 'dadecore' ); ?></button>
+        <button class="cookie-decline"><?php echo esc_html__( 'Decline', 'dadecore' ); ?></button>
+    </div>
+    <?php
+}
+add_action( 'wp_footer', 'dadecore_cookie_banner_markup' );

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -35,6 +35,14 @@ function dadecore_scripts() {
         '1.0',
         true
     );
+
+    wp_enqueue_script(
+        'dadecore-cookie-banner',
+        get_template_directory_uri() . '/assets/js/cookie-banner.js',
+        array(),
+        '1.0',
+        true
+    );
 }
 add_action( 'wp_enqueue_scripts', 'dadecore_scripts' );
 ?>

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -21,6 +21,7 @@ function dadecore_register_theme_options() {
                 'adsense_code'        => '',
                 'amazon_block'        => '',
                 'gtm_container'       => '',
+                'disable_gcm'        => 0,
                 'login_slug'          => 'login',
                 'login_attempts'      => 3,
                 'lockout_minutes'     => 15,
@@ -66,6 +67,14 @@ function dadecore_register_theme_options() {
         'dadecore_gtm_container',
         __( 'Google Tag Manager Container ID', 'dadecore' ),
         'dadecore_gtm_field',
+        'dadecore_options',
+        'dadecore_ads_section'
+    );
+
+    add_settings_field(
+        'dadecore_disable_gcm',
+        __( 'Disable Google Consent Mode', 'dadecore' ),
+        'dadecore_disable_gcm_field',
         'dadecore_options',
         'dadecore_ads_section'
     );
@@ -201,6 +210,7 @@ function dadecore_sanitize_options( $input ) {
     $output['adsense_code']  = isset( $input['adsense_code'] ) ? wp_kses_post( $input['adsense_code'] ) : '';
     $output['amazon_block']  = isset( $input['amazon_block'] ) ? wp_kses_post( $input['amazon_block'] ) : '';
     $output['gtm_container'] = isset( $input['gtm_container'] ) ? sanitize_text_field( $input['gtm_container'] ) : '';
+    $output['disable_gcm']   = isset( $input['disable_gcm'] ) ? (bool) $input['disable_gcm'] : false;
     $output['login_slug']          = isset( $input['login_slug'] ) ? sanitize_title( $input['login_slug'] ) : 'login';
     $output['login_attempts']      = isset( $input['login_attempts'] ) ? absint( $input['login_attempts'] ) : 3;
     $output['lockout_minutes']     = isset( $input['lockout_minutes'] ) ? absint( $input['lockout_minutes'] ) : 15;
@@ -257,6 +267,19 @@ function dadecore_gtm_field() {
     printf(
         '<input type="text" name="dadecore_options[gtm_container]" value="%s" class="regular-text" />',
         esc_attr( $gtm_container )
+    );
+}
+
+/**
+ * Checkbox to disable Google Consent Mode.
+ */
+function dadecore_disable_gcm_field() {
+    $options = get_option( 'dadecore_options', array() );
+    $disabled = ! empty( $options['disable_gcm'] );
+
+    printf(
+        '<input type="checkbox" name="dadecore_options[disable_gcm]" value="1" %s />',
+        checked( $disabled, true, false )
     );
 }
 


### PR DESCRIPTION
## Summary
- add cookie banner styles and script
- integrate Google Consent Mode with deferred GTM
- expose a theme option to disable consent mode

## Testing
- `php -l inc/consent.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b4192740832fbe08e1c64bcb8030